### PR TITLE
Return early if writing to closed socket/session

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -67,14 +67,16 @@ class Session extends EventEmitter {
     send_mrcp_msg(msg) {
         if(!this.mrcp_socket) {
             log.error(`${this.uuid} mrcp_socket not ready`)
+            return
         }
 
         utils.safe_write(this.mrcp_socket, msg)
     }
 
     send_rtp_data(data, marker_bit, payload_type) {
-         if(!this.rtp_session) {
+        if(!this.rtp_session) {
             log.error(`${this.uuid} rtp_session not ready`)
+            return
         }
 
         if(!marker_bit) marker_bit = 0


### PR DESCRIPTION
Currently if the socket is not yet assigned, `send_mrcp_msg` will always throw a useless exception of

`Cannot read property 'destroyed' of undefined` with a stack trace

In the MR I've returned early after the logger that prints a message about this, but it may make sense to throw a more explicit error directly instead of logging an error and then letting the internal error throw.

An explicit error of "Socket not ready" is clearer than a property read error with a log message