### PR TITLE
Allow passing `preserve_headers` option to RTP session

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -33,6 +33,7 @@ class Session extends EventEmitter {
         if(data.direction == 'out') {
              const rs_args = {
                 payload_type: data.sdp_data.rtp_payloads[0],
+                preserve_headers: data.preserve_headers,
                 ssrc: gen_random_int(0xffffffff),
             }
            

--- a/lib/sip_mrcp_stack.js
+++ b/lib/sip_mrcp_stack.js
@@ -270,6 +270,7 @@ class SipMrcpStack {
             local_rtp_port: local_rtp_port,
             direction: 'in',
             sdp_data: sdp_data,
+            preserve_headers: this.rtp_options.preserve_headers,
         }
 
         const session = this.add_new_session(uuid, data)
@@ -325,7 +326,7 @@ class SipMrcpStack {
 
     constructor(opts) {
         // opts.sip_options: same as here https://github.com/kirm/sip.js/blob/master/doc/api.markdown
-        // opts.rtp_options: {local_ip, local_ports}
+        // opts.rtp_options: {local_ip, local_ports, preserve_headers}
         // opts.mrcp_options: {local_port: YYYY}
         // opts.new_session_callback: to be called when a SIP/MRCP session creation request is received.
 
@@ -430,6 +431,7 @@ class SipMrcpStack {
                             direction: 'out',
                             sdp_data: sdp_data,
                             mrcp_uuid: sdp_data.channel,
+                            preserve_headers: this.rtp_options.preserve_headers,
                         }
 
                         const session = this.add_new_session(uuid, data)


### PR DESCRIPTION
Depends on [this contribution](https://github.com/MayamaTakeshi/rtp-session/pull/7/files) to add the option being used here.